### PR TITLE
API key leak fixed

### DIFF
--- a/app.js
+++ b/app.js
@@ -25,7 +25,7 @@ app.get('/upcomingContests', (req, res, next) => {
       { url: `${clistUrl}&resource=${q.resource}&end__gt=${q.end__gt}&start__gt=${q.start__gt}&limit=150` },
       (error, response, body) => {
         if (error || response.statusCode !== 200) {
-          return res.status(500).json({ type: 'error', message: error, url: `${clistUrl}&resource=${q.resource}&end__gt=${q.end__gt}&start__gt=${q.start__gt}&limit=150`});
+          return res.status(500).json({ type: 'error', message: error, query: `resource=${q.resource}&end__gt=${q.end__gt}&start__gt=${q.start__gt}&limit=150`});
         }
         res.json(JSON.parse(body));
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,7 @@
       "dependencies": {
         "dotenv": "^16.0.3",
         "express": "^4.18.2",
-        "request": "^2.88.2",
-        "serverless-http": "^3.1.0"
+        "request": "^2.88.2"
       },
       "devDependencies": {
         "nodemon": "^2.0.22"
@@ -1148,14 +1147,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/serverless-http": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/serverless-http/-/serverless-http-3.2.0.tgz",
-      "integrity": "sha512-QvSyZXljRLIGqwcJ4xsKJXwkZnAVkse1OajepxfjkBXV0BMvRS5R546Z4kCBI8IygDzkQY0foNPC/rnipaE9pQ==",
-      "engines": {
-        "node": ">=12.0"
-      }
-    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -2229,11 +2220,6 @@
         "parseurl": "~1.3.3",
         "send": "0.18.0"
       }
-    },
-    "serverless-http": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/serverless-http/-/serverless-http-3.2.0.tgz",
-      "integrity": "sha512-QvSyZXljRLIGqwcJ4xsKJXwkZnAVkse1OajepxfjkBXV0BMvRS5R546Z4kCBI8IygDzkQY0foNPC/rnipaE9pQ=="
     },
     "setprototypeof": {
       "version": "1.2.0",


### PR DESCRIPTION
When we try to make an invalid query. The response include the URL to which the query was made, and that URL also includes the username and api key of the owner. So simply prevent this from happening we remove the { clistUrl } from the response. And since the output looks more like the query that was made instead of the URL. So I thought it would be better to rename it as query.

Ways to reproduce : 

Enter the URL : https://cp-calendar-server.vercel.app/upcomingContests
The response will be like this : 

![image](https://github.com/getlost01/cp-calendar-server/assets/71769231/6ab4f893-ede7-43ca-b6e6-abe3e35bddf7)

Steps Ahead : 
1. Change the API key since it is already public now.